### PR TITLE
Copy base config files into output folder

### DIFF
--- a/packages/create-codes/src/index.ts
+++ b/packages/create-codes/src/index.ts
@@ -61,6 +61,16 @@ function copyBase(appDir: string, useEslint: boolean) {
     filter: (src) => !baseExclude.includes(path.basename(src)),
   });
 
+  fse.copySync(
+    path.resolve(baseSourceDir, "vite.config.ts"),
+    path.resolve(appDir, "vite.config.ts")
+  );
+
+  fse.copySync(
+    path.resolve(baseSourceDir, "tsconfig.json"),
+    path.resolve(appDir, "tsconfig.json")
+  );
+
   packageObjs = deepMergeObjects(
     packageObjs,
     fse.readJsonSync(path.join(baseSourceDir, "package.json"))


### PR DESCRIPTION
Fixes #768

## What I did
Copied `vite-config-ts` and `tsconfig.json` into the output project folder.

## How to test

- [x] Is this testable with jest or e2e?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.
