### PR TITLE
Add E2E test web server config

### DIFF
--- a/code/react/base/README.md
+++ b/code/react/base/README.md
@@ -62,8 +62,12 @@ npm run storybook
 npm run build:e2e
 
 # (If Playwright was included in the project)
+# Build and deploy a local web server for E2E testing
+npm run setup:e2e
+
+# (If Playwright was included in the project)
 # Run E2E tests with Playwright
-npm run e2e
+npm run test:e2e
 
 ```
 

--- a/code/react/base/package.json
+++ b/code/react/base/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "dev": "vite --port 3000",
     "build": "tsc && vite build",
-    "build:e2e": "tsc && vite build --mode development",
     "preview": "vite preview --port 3000",
     "start": "vite preview --port 3000",
     "type": "tsc --noEmit",

--- a/code/react/base/package.json
+++ b/code/react/base/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "vite --port 3000",
     "build": "tsc && vite build",
+    "build:dev": "tsc && vite build --mode development",
     "preview": "vite preview --port 3000",
     "start": "vite preview --port 3000",
     "type": "tsc --noEmit",

--- a/packages/create-codes/templates/__shared/playwright/package.json
+++ b/packages/create-codes/templates/__shared/playwright/package.json
@@ -1,7 +1,6 @@
 {
   "scripts": {
-    "build:e2e": "tsc && vite build --mode development",
-    "setup:e2e": "npm run build:e2e && vite preview --port 3000",
+    "setup:e2e": "npm run build:dev && vite preview --port 3000",
     "test:e2e": "playwright test"
   },
   "devDependencies": {

--- a/packages/create-codes/templates/__shared/playwright/package.json
+++ b/packages/create-codes/templates/__shared/playwright/package.json
@@ -1,6 +1,8 @@
 {
   "scripts": {
-    "e2e": "playwright test"
+    "build:e2e": "tsc && vite build --mode development",
+    "setup:e2e": "npm run build:e2e && vite preview --port 3000",
+    "test:e2e": "playwright test"
   },
   "devDependencies": {
     "@playwright/test": "1.30.0",

--- a/packages/create-codes/templates/__shared/playwright/playwright.config.ts
+++ b/packages/create-codes/templates/__shared/playwright/playwright.config.ts
@@ -8,6 +8,11 @@ const config: PlaywrightTestConfig = {
   retries: CI ? 2 : 0,
   globalSetup: resolve("./__tests__/utils/global-setup"),
   testDir: "__tests__",
+  webServer: {
+    command: "npm run setup:e2e",
+    url: "http://localhost:3000",
+    reuseExistingServer: !CI,
+  },
   use: {
     baseURL: "http://localhost:3000",
     headless: CI,

--- a/turbo.json
+++ b/turbo.json
@@ -6,9 +6,9 @@
     "build": {
       "dependsOn": ["^build"]
     },
-    "build:e2e": {},
+    "build:dev": {},
     "preview": {
-      "dependsOn": ["build:e2e"]
+      "dependsOn": ["build:dev"]
     },
     "start": {
       "dependsOn": ["build"]


### PR DESCRIPTION
<!-- Please provide a descriptive title for your pull request -->

## Pull Request Checklist
- [x] I have checked that this pull request is not a duplicate of a pre-existing pull request
- [x] I have self-reviewed my changes
  - [x] There are no spelling mistakes
  - [x] There are no remaining debug log prints (i.e. `console.log()`)
  - [x] Comments were written for complex code
- [x] I have checked that all tests are passing (for bug fixes and enhancements)
  - [x] CLI Test (`npm run test:cli`)
  - [x] Unit Test (`npm run test:modules`)
  - [x] E2E Test (`npm run e2e`)
- [x] I have added and/or modified relevant tests for my changes (for bug fixes and enhancements)
- [x] I have added and/or modified relevant documentations for my changes (if necessary)

## Description

### Context

Resolves #1131

I added the web server config in the [playwright.config.ts](packages/create-codes/templates/__shared/playwright/playwright.config.ts) template, and updated the [scripts](packages/create-codes/templates/__shared/playwright/package.json) used for E2E tests.

### Before

When running the E2E test on the generated project, the tests fail due to being unable to connect to the specified URL, `http://localhost:3000`. You need to run other scripts to build and deploy a local server before running the tests.

### After

You only need to run `test:e2e` to run the E2E tests. If there is already a web server running on the specified URL, it will use that. If there is no existing web server, the script will build and deploy one before running the tests, and automatically close it afterward. 

## :warning: Breaking changes

N/A

## Notes

<!-- Feel free to write any other relevant or potentially useful information here. -->
