### PR TITLE
Fix React's RESTful module's unit tests 

### DIFF
--- a/code/react/module-api-restful/src/hooks/use-user.test.tsx
+++ b/code/react/module-api-restful/src/hooks/use-user.test.tsx
@@ -68,6 +68,7 @@ describe("useAddUser", () => {
     const { result } = renderHook(useAddUser, { wrapper });
 
     await act(async () => result.current.mutate({ name: "Ringo" }));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(result.current.data).toMatchObject({ name: "Ringo" });
     expect(result.current.isError).toBe(false);
@@ -84,6 +85,7 @@ describe("useUpdateUser", () => {
         name: "Brian",
       })
     );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(result.current.data).toStrictEqual({
       id: "f79e82e8-c34a-4dc7-a49e-9fadc0979fda",


### PR DESCRIPTION
<!-- Please provide a descriptive title for your pull request -->

## Pull Request Checklist
- [ ] I have checked that this pull request is not a duplicate of a pre-existing pull request
- [ ] I have self-reviewed my changes
  - [ ] There are no spelling mistakes
  - [ ] There are no remaining debug log prints (i.e. `console.log()`)
  - [ ] Comments were written for complex code
- [ ] I have checked that all tests are passing (for bug fixes and enhancements)
  - [ ] CLI Test (`npm run test:cli`)
  - [ ] Unit Test (`npm run test:modules`)
  - [ ] E2E Test (`npm run e2e`)
- [ ] I have added and/or modified relevant tests for my changes (for bug fixes and enhancements)
- [ ] I have added and/or modified relevant documentations for my changes (if necessary)

## Description

### Context
Resolves #1128 

This fixes the failing unit tests (`useAddUser`, `useUpdateUser`) for React's RESTful module. 


### Before

The unit tests fail with the error below, due to the promise not being resolved yet.
![image](https://github.com/monstar-lab-oss/ml-frontend/assets/3384105/b1732b94-7424-4d70-ac4d-9781c212752e)


### After

The unit tests wait for the hook to return successfully before asserting the resolved value.

![image](https://github.com/monstar-lab-oss/ml-frontend/assets/3384105/42a1217e-5e74-48f7-95bf-69e363207104)


## :warning: Breaking changes

N/A

## Notes

This does not occur on GitHub's CI, for some reason. When I tried rearranging the test order the following way:
- `useUpdateUser` before `useAddUser` -> `useUpdateUser` fails instead of `useAddUser`.
- `useRemoveUser` before both `useAddUser` and `useUpdateUser` -> all tests pass 🤔 

All I can think of right now is that it's a `Promise` issue, though it would require more time to further investigate the root.
