### PR TITLE
Fix CLI test failure by adjusting build process

### DIFF
--- a/.changeset/honest-bulldogs-fetch.md
+++ b/.changeset/honest-bulldogs-fetch.md
@@ -1,0 +1,5 @@
+---
+"start-frontend": minor
+---
+
+Fix CLI test failure by adjusting build process

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ml-frontend",
   "scripts": {
-    "test:cli": "turbo run build --filter=start-frontend test --filter=start-frontend",
+    "test:cli": "turbo run build --filter=start-frontend && turbo run test --filter=start-frontend",
     "test:modules": "turbo run test --filter='./code/*' && turbo run test --filter='./code/*/*'",
     "e2e": "turbo run e2e",
     "type": "turbo run type",


### PR DESCRIPTION
<!-- Please provide a descriptive title for your pull request -->

## Pull Request Checklist
- [x] I have checked that this pull request is not a duplicate of a pre-existing pull request
- [x] I have self-reviewed my changes
  - [x] There are no spelling mistakes
  - [x] There are no remaining debug log prints (i.e. `console.log()`)
  - [x] Comments were written for complex code
- [x] I have checked that all tests are passing (for bug fixes and enhancements)
  - [x] CLI Test (`npm run test:cli`)
  - [x] Unit Test (`npm run test:modules`)
  - [x] E2E Test (`npm run e2e`)
- [x] I have added and/or modified relevant tests for my changes (for bug fixes and enhancements)
- [ ] I have added and/or modified relevant documentations for my changes (if necessary)

## Description

This pull request fixes the issue with the start frontend CLI test that was failing. The root cause was that the build process was being performed before testing, but the context in which the tests were run was causing the build artifacts to be deleted.

To address this, I modified the CLI test script to build directly before running the tests. This ensures that the necessary build artifacts are present when the tests are executed.

### Context

Resolves #1293

### Before

The build process was performed before the tests, but the context in which the tests were run was causing the build artifacts to be deleted. This led to the start frontend CLI test failing because the required build files were missing.

### After

The CLI test script builds directly before running the tests. This ensures that the build artifacts are present and the start frontend CLI test can run successfully without encountering missing files.