### PR TITLE
Allow auto-merging for Renovate's patch updates

### DIFF
--- a/.changeset/friendly-dancers-doubt.md
+++ b/.changeset/friendly-dancers-doubt.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+Allow auto-merging for Renovate's patch updates

--- a/renovate.json
+++ b/renovate.json
@@ -11,11 +11,9 @@
   "packageRules": [
     {
       "matchUpdateTypes": [
-        "major",
-        "minor",
-        "pin"
+        "patch"
       ],
-      "automerge": false
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
<!-- Please provide a descriptive title for your pull request -->

## Pull Request Checklist
- [x] I have checked that this pull request is not a duplicate of a pre-existing pull request
- [x] I have self-reviewed my changes
  - [x] There are no spelling mistakes
  - [x] There are no remaining debug log prints (i.e. `console.log()`)
  - [x] Comments were written for complex code
- [x] I have checked that all tests are passing (for bug fixes and enhancements)
  - [x] CLI Test (`npm run test:cli`)
  - [x] Unit Test (`npm run test:modules`)
  - [x] E2E Test (`npm run e2e`)
- [x] I have added and/or modified relevant tests for my changes (for bug fixes and enhancements)
- [x] I have added and/or modified relevant documentations for my changes (if necessary)

## Description

We decided to allow auto-merging for Renovate's patch updates.

### Context
<!--
You can link a pull request to an issue by using a supported keyword. (e.g. `resolve` `fix`)

Reference: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

On August 23rd, I discussed with @ptrkdan about the issue of too many Renovate PRs piling up, making it difficult for people to manage them. We agreed that maintainers should directly review minor and major updates for now, but we'll allow auto-merging for patch updates.

<!-- Explain the purpose of the pull request and any reason behind the changes you made. -->

## Notes

<!-- Feel free to write any other relevant or potentially useful information here. -->

Maintainers will review the PRs for major and minor updates.